### PR TITLE
Migrate to pnpm v11

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,6 +12,8 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.platform.shell }}
+    env:
+      PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE: 'false'
     name: The build process
     runs-on: ${{ matrix.platform.os }}
     steps:

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-git-checks=false
-ignore-workspace-root-check=true
-link-workspace-packages=true

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^6.1.3",
     "typescript": "~6.0.3"
   },
-  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800",
+  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065",
   "engines": {
     "node": "^22.23.1 || ^24.2.0 || >=26.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,24 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies:
+      '@pnpm/plugin-types-fixer':
+        specifier: 0.1.0
+        version: 0.1.0
+
+packages:
+
+  '@pnpm/plugin-types-fixer@0.1.0':
+    resolution: {integrity: sha512-bLww63gRHi7siYTqFJb5qNdcXadU0jv20Et6z5AryMZ7FlLolbEJOrXLpg8+amQZNHHNW1dfFUBGVw/9ezQbFg==}
+
+snapshots:
+
+  '@pnpm/plugin-types-fixer@0.1.0': {}
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 configDependencies:
   '@pnpm/plugin-types-fixer': 0.1.0+sha512-bLww63gRHi7siYTqFJb5qNdcXadU0jv20Et6z5AryMZ7FlLolbEJOrXLpg8+amQZNHHNW1dfFUBGVw/9ezQbFg==
+enableGlobalVirtualStore: true
 engineStrict: true
 gitChecks: false
 ignoreWorkspaceRootCheck: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
 configDependencies:
   '@pnpm/plugin-types-fixer': 0.1.0+sha512-bLww63gRHi7siYTqFJb5qNdcXadU0jv20Et6z5AryMZ7FlLolbEJOrXLpg8+amQZNHHNW1dfFUBGVw/9ezQbFg==
+engineStrict: true
+gitChecks: false
+ignoreWorkspaceRootCheck: true
+linkWorkspacePackages: true
+pmOnFail: warn
 shellEmulator: true


### PR DESCRIPTION
This pull request updates the project's package manager configuration and workspace settings to improve compatibility and enforce stricter engine requirements. The most significant changes include upgrading the `pnpm` version, enabling global virtual store, and explicitly setting several workspace options.

**Package Manager and Dependency Management:**

* Upgraded the `pnpm` version in `package.json` from `10.33.4` to `11.15.1` to ensure compatibility with newer features and plugins.
* Added a new `pnpm-lock.yaml` file, which records the current dependency graph and plugin usage, including the `@pnpm/plugin-types-fixer` plugin.

**Workspace and Configuration Settings:**

* Updated `pnpm-workspace.yaml` to enable global virtual store, enforce strict engine requirements, disable git checks, ignore workspace root check, link workspace packages, and set failure behavior to warning.
* Removed now-redundant per-project `.npmrc` settings that are handled by the workspace configuration.